### PR TITLE
업로드 모달 스크롤바 추가

### DIFF
--- a/components/common/Header/UploadModal/FileUploadView.tsx
+++ b/components/common/Header/UploadModal/FileUploadView.tsx
@@ -2,7 +2,7 @@ import FileUploader from "@/components/atoms/FileUploader";
 
 export default function FileUploadView() {
   return (
-    <div className="px-6">
+    <>
       <div className="w-full border h-60 mb-2.5 flex flex-col justify-center items-center border-primary-border_gray gap-2.5 rounded-lg">
         <FileUploader label="동영상 업로드" />
         <p>동영상 파일을 드래그 앤 드롭하여 업로드</p>
@@ -11,6 +11,6 @@ export default function FileUploadView() {
         <FileUploader label="웹 파일 선택" />
         <p>웹 파일을 드래그 앤 드롭하여 업로드</p>
       </div>
-    </div>
+    </>
   );
 }

--- a/components/common/Header/UploadModal/FileUploadView.tsx
+++ b/components/common/Header/UploadModal/FileUploadView.tsx
@@ -2,7 +2,7 @@ import FileUploader from "@/components/atoms/FileUploader";
 
 export default function FileUploadView() {
   return (
-    <>
+    <div className="px-6">
       <div className="w-full border h-60 mb-2.5 flex flex-col justify-center items-center border-primary-border_gray gap-2.5 rounded-lg">
         <FileUploader label="동영상 업로드" />
         <p>동영상 파일을 드래그 앤 드롭하여 업로드</p>
@@ -11,6 +11,6 @@ export default function FileUploadView() {
         <FileUploader label="웹 파일 선택" />
         <p>웹 파일을 드래그 앤 드롭하여 업로드</p>
       </div>
-    </>
+    </div>
   );
 }

--- a/components/common/Header/UploadModal/FormView.tsx
+++ b/components/common/Header/UploadModal/FormView.tsx
@@ -5,7 +5,7 @@ import SearchIcon from "@/components/Icon/SearchIcon";
 
 export default function FormView() {
   return (
-    <div className="w-full h-[32.5rem] overflow-auto">
+    <div className="w-full h-[32.5rem] overflow-auto px-6">
       <LabelForm label="제목" className="mb-6">
         <Input className="w-full" placeholder="제목" />
       </LabelForm>

--- a/components/common/Header/UploadModal/FormView.tsx
+++ b/components/common/Header/UploadModal/FormView.tsx
@@ -5,7 +5,7 @@ import SearchIcon from "@/components/Icon/SearchIcon";
 
 export default function FormView() {
   return (
-    <div className="w-full">
+    <div className="w-full h-[32.5rem] overflow-auto">
       <LabelForm label="제목" className="mb-6">
         <Input className="w-full" placeholder="제목" />
       </LabelForm>

--- a/components/common/Header/UploadModal/FormView.tsx
+++ b/components/common/Header/UploadModal/FormView.tsx
@@ -15,7 +15,7 @@ export default function FormView() {
     scrollbar-track-inherit 
     scrollbar-thumb-gray-300 
     scrollbar-thumb-rounded-md 
-    hover:scrollbar-thumb-[#989898]
+    hover:scrollbar-thumb-primary-scroll_gray
     `;
   };
 

--- a/components/common/Header/UploadModal/FormView.tsx
+++ b/components/common/Header/UploadModal/FormView.tsx
@@ -1,6 +1,7 @@
 import Input from "@/components/atoms/Input";
 import LabelForm from "@/components/atoms/LabelForm";
 import Textarea from "@/components/atoms/Textarea";
+import SearchIcon from "@/components/Icon/SearchIcon";
 
 export default function FormView() {
   return (
@@ -11,8 +12,9 @@ export default function FormView() {
       <LabelForm label="설명" className="mb-6">
         <Textarea className="w-full" placeholder="설명" />
       </LabelForm>
-      <LabelForm label="기술스택(중복선택 가능)" className="mb-6">
-        <Input className="w-full" placeholder="기술스택을 입력하세요" />
+      <LabelForm label="기술스택(중복선택 가능)" className="relative mb-6">
+        <SearchIcon className="absolute top-9 left-3 w-[0.8125rem]" />
+        <Input className="w-full pl-8" placeholder="기술스택을 입력하세요" />
       </LabelForm>
       <LabelForm label="참여자 아이디" className="mb-6">
         <Input className="w-full" placeholder="#해시태그" />

--- a/components/common/Header/UploadModal/FormView.tsx
+++ b/components/common/Header/UploadModal/FormView.tsx
@@ -5,7 +5,7 @@ import SearchIcon from "@/components/Icon/SearchIcon";
 
 export default function FormView() {
   return (
-    <div className="w-full h-[32.5rem] overflow-auto px-6">
+    <div className="w-full h-[32.5rem] overflow-auto pr-6 scrollbar:none">
       <LabelForm label="제목" className="mb-6">
         <Input className="w-full" placeholder="제목" />
       </LabelForm>

--- a/components/common/Header/UploadModal/FormView.tsx
+++ b/components/common/Header/UploadModal/FormView.tsx
@@ -4,8 +4,23 @@ import Textarea from "@/components/atoms/Textarea";
 import SearchIcon from "@/components/Icon/SearchIcon";
 
 export default function FormView() {
+  const getFormViewCss = () => {
+    return `w-full 
+    h-[32.5rem] 
+    overflow-auto 
+    pr-6 
+    pl-[0.0625rem] 
+    scrollbar 
+    scrollbar-w-[0.3125rem] 
+    scrollbar-track-inherit 
+    scrollbar-thumb-gray-300 
+    scrollbar-thumb-rounded-md 
+    hover:scrollbar-thumb-[#989898]
+    `;
+  };
+
   return (
-    <div className="w-full h-[32.5rem] overflow-auto pr-6 scrollbar:none">
+    <div className={getFormViewCss()}>
       <LabelForm label="제목" className="mb-6">
         <Input className="w-full" placeholder="제목" />
       </LabelForm>

--- a/components/common/Header/UploadModal/SubmitView.tsx
+++ b/components/common/Header/UploadModal/SubmitView.tsx
@@ -2,7 +2,7 @@ import Radio from "@/components/atoms/Radio";
 
 export default function SubmitView() {
   return (
-    <div>
+    <div className="px-6">
       <h2 className="text-base mb-large">공개범위</h2>
       <form>
         <Radio

--- a/components/common/Header/UploadModal/SubmitView.tsx
+++ b/components/common/Header/UploadModal/SubmitView.tsx
@@ -2,7 +2,7 @@ import Radio from "@/components/atoms/Radio";
 
 export default function SubmitView() {
   return (
-    <div className="px-6">
+    <>
       <h2 className="text-base mb-large">공개범위</h2>
       <form>
         <Radio
@@ -25,6 +25,6 @@ export default function SubmitView() {
           description="나와 내가 선택한 사람만 볼 수 있습니다."
         />
       </form>
-    </div>
+    </>
   );
 }

--- a/components/common/Modal/View.tsx
+++ b/components/common/Modal/View.tsx
@@ -31,7 +31,7 @@ export default function ModalView({
           <h1 className="font-bold text-xl">{title}</h1>
           <XIcon className="cursor-pointer" onClick={onClose} />
         </div>
-        <div className="flex flex-col mt-6 gap-2.5 px-4 pb-40">{content}</div>
+        <div className="flex flex-col mt-6 gap-2.5 px-10 pb-40">{content}</div>
       </div>
     </>
   );

--- a/components/common/Modal/View.tsx
+++ b/components/common/Modal/View.tsx
@@ -31,7 +31,9 @@ export default function ModalView({
           <h1 className="font-bold text-xl">{title}</h1>
           <XIcon className="cursor-pointer" onClick={onClose} />
         </div>
-        <div className="flex flex-col mt-6 gap-2.5 px-10">{content}</div>
+        <div className="flex flex-col mt-6 gap-2.5 px-10 pb-40 overflow-auto">
+          {content}
+        </div>
       </div>
     </>
   );

--- a/components/common/Modal/View.tsx
+++ b/components/common/Modal/View.tsx
@@ -31,9 +31,7 @@ export default function ModalView({
           <h1 className="font-bold text-xl">{title}</h1>
           <XIcon className="cursor-pointer" onClick={onClose} />
         </div>
-        <div className="flex flex-col mt-6 gap-2.5 px-10 pb-40 overflow-auto">
-          {content}
-        </div>
+        <div className="flex flex-col mt-6 gap-2.5 px-4 pb-40">{content}</div>
       </div>
     </>
   );

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "react-dom": "18.2.0",
     "react-hook-form": "^7.39.3",
     "react-markdown": "^8.0.4",
-    "recoil": "^0.7.6"
+    "recoil": "^0.7.6",
+    "tailwind-scrollbar": "^2.1.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.29.1",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -82,5 +82,8 @@ module.exports = {
       },
     },
   },
-  plugins: [],
+  plugins: [
+    // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
+    require("tailwind-scrollbar")({ nocompatible: true }),
+  ],
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -69,6 +69,7 @@ module.exports = {
           dark_gray: "#3A3A3A",
           light_gray: "#F9F9F9",
           border_gray: "#D9D9D9",
+          scroll_gray: "#989898",
         },
         secondary: {},
         background: {},

--- a/yarn.lock
+++ b/yarn.lock
@@ -4515,6 +4515,11 @@ symbol-tree@^3.2.4:
   resolved "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
+tailwind-scrollbar@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tailwind-scrollbar/-/tailwind-scrollbar-2.1.0.tgz#46e0b8788cef75387f9d163a5ec82b8cacd66c44"
+  integrity sha512-zpvY5mDs0130YzYjZKBiDaw32rygxk5RyJ4KmeHjGnwkvbjm/PszON1m4Bbt2DkMRIXlXsfNevykAESgURN4KA==
+
 tailwindcss@^3.2.1:
   version "3.2.4"
   resolved "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.2.4.tgz"


### PR DESCRIPTION
## 지라 이슈
https://qkrjh0904.atlassian.net/browse/BSSMH-64

## 스크린샷
‼‼ 스크롤바 생성을 위해서 개발자 도구로 textarea를 크게 키웠습니다. ‼‼

https://user-images.githubusercontent.com/80014454/212546401-cebb9787-f951-4490-8acf-5623b2928242.mov

## 변경한 것
기술스택 검색 input에 돋보기 아이콘을 추가했습니다.
기술스택의 개수가 늘어나면 스크롤바가 생기도록 변경하였습니다.

원래대로라면 아래와 같이 스크롤바가 input과 겹치는 현상이 발생하여
<img width="350" alt="스크린샷 2023-01-15 오후 11 20 14" src="https://user-images.githubusercontent.com/80014454/212546447-e3524dee-92c0-4b10-86a6-c00a6b7f7100.png">

겹치게 하지 않기 위해서 padding을 두번에 걸쳐 줬습니다. ([해당 comment](https://github.com/bssm-portfolio/app/pull/10#discussion_r1070609192)를 참고해주세요!)
<img width="350" alt="스크린샷 2023-01-15 오후 11 20 46" src="https://user-images.githubusercontent.com/80014454/212546462-ec5c1770-54ec-47d9-8a05-8a5b43ebaecd.png">
