### PR TITLE
Fix: Chip.Group width 고정으로 인한 줄 내려감 수정

### DIFF
--- a/components/atoms/Chip.tsx
+++ b/components/atoms/Chip.tsx
@@ -1,22 +1,23 @@
+import { PortfolioSidebarType } from "@/types/portfolio.interface";
 import classNames from "classnames";
 import { ReactNode } from "react";
 
 interface ChipGroupProps {
   children: ReactNode;
   className?: string;
+  type?: PortfolioSidebarType;
 }
 
 interface ChipProps {
   children: ReactNode;
 }
 
-function Group({ children, className }: ChipGroupProps) {
+function Group({ children, className, type = "main" }: ChipGroupProps) {
   return (
     <div
-      className={`${classNames(
-        className,
-        "flex gap-1 flex-wrap xl:w-[8.4375rem]",
-      )}`}
+      className={`${classNames(className, "flex gap-1 flex-wrap", {
+        "xl:w-[8.4375rem]": type === "portfolio",
+      })}`}
     >
       {children}
     </div>

--- a/components/portfolio/SideMenuItem.tsx
+++ b/components/portfolio/SideMenuItem.tsx
@@ -27,7 +27,7 @@ export default function SideMenuItem() {
               <span className="font-bold text-small block mb-xsmall">
                 {portfolio.writer.name}
               </span>
-              <Chip.Group>
+              <Chip.Group type="portfolio">
                 {portfolio.skillList.map((skillData) => {
                   return <Chip.Item key={skillData}>{skillData}</Chip.Item>;
                 })}

--- a/types/portfolio.interface.ts
+++ b/types/portfolio.interface.ts
@@ -3,6 +3,7 @@ import { MemberWithoutIntroduction } from "./member.interface";
 
 type PortfolioType = "VIDEO" | "URL";
 type PortfolioScope = "PUBLIC" | "PRIVATE" | "PROTECTED";
+export type PortfolioSidebarType = "main" | "portfolio";
 
 export type Portfolio = {
   portfolioId: number;


### PR DESCRIPTION
## 지라 이슈
https://qkrjh0904.atlassian.net/browse/BSSMH-47

## 스크린샷
<img width="353" alt="스크린샷 2023-01-17 오후 11 28 11" src="https://user-images.githubusercontent.com/80014454/212925249-a3a50454-3f95-429d-8047-0616e184d525.png">

## 변경한 것
자꾸 번거롭게 PR드려서 죄송합니다!!!!!!!
머지 하고 나서야 문제점이 자꾸 보이네요.....

`Chips.Group`에 `width`를 강제로 지정하게 되면 아래의 이미지처럼 `Chips.Item`이 두줄로 표시되는 현상이 있었습니다.. 
그래서 `Chips.Group`에 `type` 이라는 `props`를 추가해서 `type="main" (메인화면의 아이템)`, `type="portfolio" (포트폴리오 상세화면 사이드바의 아이템)` 두가지 타입으로 지정해서 `width`를 조건부로 추가해주는 구조로 변경해서 `Chips.Item`이 두줄로 표시되는 현상을 해결하였습니다!

<img width="353" alt="스크린샷 2023-01-17 오후 11 28 19" src="https://user-images.githubusercontent.com/80014454/212925636-253428bf-42f5-4d79-9dda-daac106e6a2b.png">
