### PR TITLE
portfolio의 길이가 0일 때 전체선택이 활성화되는 버그 수정

### DIFF
--- a/components/contents/DataGrid.tsx
+++ b/components/contents/DataGrid.tsx
@@ -28,7 +28,7 @@ export default function DataGrid({
       return;
     }
     setCheckedPortfolioIdList((prev) =>
-      prev.filter((checked) => checked !== portfolioId),
+      prev.filter((checkedPortfolioId) => checkedPortfolioId !== portfolioId),
     );
   };
 
@@ -40,6 +40,12 @@ export default function DataGrid({
       return;
     }
     setCheckedPortfolioIdList([]);
+  };
+
+  const isCheckedAll = () => {
+    if (checkedPortfolioIdList.length === 0) return false;
+    if (checkedPortfolioIdList.length === portfolioList.length) return true;
+    return false;
   };
 
   const onDragEnd = ({ source, destination }: DropResult) => {
@@ -81,7 +87,7 @@ export default function DataGrid({
             id="select-all"
             className="mr-3"
             onChange={(event) => handleAllCheck(event.target.checked)}
-            checked={checkedPortfolioIdList.length === portfolioList.length}
+            checked={isCheckedAll()}
             label="전체선택"
           />
         </span>

--- a/components/contents/DataGrid.tsx
+++ b/components/contents/DataGrid.tsx
@@ -22,16 +22,6 @@ export default function DataGrid({
   >([]);
   const [isEnabled, setIsEnabled] = useState(false);
 
-  const handleSingleCheck = (isChecked: boolean, portfolioId: number) => {
-    if (isChecked) {
-      setCheckedPortfolioIdList((prev) => [...prev, portfolioId]);
-      return;
-    }
-    setCheckedPortfolioIdList((prev) =>
-      prev.filter((checkedPortfolioId) => checkedPortfolioId !== portfolioId),
-    );
-  };
-
   const handleAllCheck = (isChecked: boolean) => {
     if (isChecked) {
       setCheckedPortfolioIdList(
@@ -67,7 +57,6 @@ export default function DataGrid({
 
   useEffect(() => {
     const animation = requestAnimationFrame(() => setIsEnabled(true));
-
     return () => {
       cancelAnimationFrame(animation);
       setIsEnabled(false);
@@ -108,7 +97,7 @@ export default function DataGrid({
                 <DataGridItem
                   portfolio={portfolio}
                   checkedList={checkedPortfolioIdList}
-                  handleSingleCheck={handleSingleCheck}
+                  setCheckedPortfolioIdList={setCheckedPortfolioIdList}
                   router={router}
                   key={portfolio.portfolioId}
                   idx={idx}

--- a/components/contents/DataGrid.tsx
+++ b/components/contents/DataGrid.tsx
@@ -34,8 +34,7 @@ export default function DataGrid({
 
   const isCheckedAll = () => {
     if (checkedPortfolioIdList.length === 0) return false;
-    if (checkedPortfolioIdList.length === portfolioList.length) return true;
-    return false;
+    return checkedPortfolioIdList.length === portfolioList.length;
   };
 
   const onDragEnd = ({ source, destination }: DropResult) => {

--- a/components/contents/DataGridItem.tsx
+++ b/components/contents/DataGridItem.tsx
@@ -2,6 +2,7 @@ import { Portfolio } from "@/types/portfolio.interface";
 import { getFileDownloadUrl } from "@/utils/file";
 import Image from "next/image";
 import { NextRouter } from "next/router";
+import { Dispatch, SetStateAction } from "react";
 import { Draggable } from "react-beautiful-dnd";
 import CheckBox from "../atoms/CheckBox";
 import HamburgerIcon from "../Icon/HamburgerIcon";
@@ -9,7 +10,7 @@ import HamburgerIcon from "../Icon/HamburgerIcon";
 interface DataGridItemProps {
   portfolio: Portfolio;
   checkedList: number[];
-  handleSingleCheck: (isChecked: boolean, portfolioId: number) => void;
+  setCheckedPortfolioIdList: Dispatch<SetStateAction<number[]>>;
   router: NextRouter;
   idx: number;
 }
@@ -17,11 +18,11 @@ interface DataGridItemProps {
 export default function DataGridItem({
   portfolio,
   checkedList,
-  handleSingleCheck,
+  setCheckedPortfolioIdList,
   router,
   idx,
 }: DataGridItemProps) {
-  const getBodyCss = (): string => {
+  const getBodyCss = () => {
     return `grid 
     grid-cols-[3.375rem_1fr_7.75rem_7.75rem_7.75rem] 
     items-center 
@@ -29,6 +30,20 @@ export default function DataGridItem({
     border-b 
     border-b-primary-border_gray 
     select-none`;
+  };
+
+  const handleSingleCheck = (isChecked: boolean, portfolioId: number) => {
+    if (isChecked) {
+      setCheckedPortfolioIdList((prev) => [...prev, portfolioId]);
+      return;
+    }
+    setCheckedPortfolioIdList((prev) =>
+      prev.filter((checkedPortfolioId) => checkedPortfolioId !== portfolioId),
+    );
+  };
+
+  const isCheckedSingle = (portfolioId: number) => {
+    return checkedList.includes(portfolioId);
   };
 
   return (
@@ -48,7 +63,7 @@ export default function DataGridItem({
           <div className="flex items-center pl-6 text-start">
             <CheckBox
               value={portfolio.portfolioId}
-              checked={checkedList.includes(portfolio.portfolioId)}
+              checked={isCheckedSingle(portfolio.portfolioId)}
               onChange={(event) =>
                 handleSingleCheck(event.target.checked, portfolio.portfolioId)
               }


### PR DESCRIPTION
## 지라 이슈
https://qkrjh0904.atlassian.net/browse/BSSMH-51

## 스크린샷

https://user-images.githubusercontent.com/80014454/214096253-25d803b8-8390-4ff8-935d-477dd266c7ce.mov

<img width="1560" alt="스크린샷 2023-01-24 오전 1 36 15" src="https://user-images.githubusercontent.com/80014454/214096266-0c3afa02-c9d2-4fc4-89e3-05c9d6e292dc.png">


## 변경한 것
1. 처음 렌더링 될 때 잠깐 그리고 portfolioList의 길이가 0인 경우 전체선택이 활성화 되는 이슈를 해결했습니다.
2. datagrid의 tr에만 쓰이는 함수는 tr파일로 옮겼습니다.

‼️ 아래는 현재 배포된 페이지 스크린샷 입니다 ‼️
<img width="1615" alt="스크린샷 2023-01-24 오전 1 01 58" src="https://user-images.githubusercontent.com/80014454/214096286-8e04e990-d218-4d36-8ea6-86d4be149113.png">

