### PR TITLE
댓글 수정, 삭제 기능 추가

### DIFF
--- a/apis/httpClient.ts
+++ b/apis/httpClient.ts
@@ -27,9 +27,8 @@ export class HttpClient {
     return this.api.get("/", { ...HttpClient.clientConfig, ...requestConfig });
   }
 
-  getById(requestConfig: AxiosRequestConfig) {
-    const { params } = requestConfig;
-    return this.api.get(`/${"id" in params ? params.id : "/:id"}`, {
+  getById(id: number, requestConfig?: AxiosRequestConfig) {
+    return this.api.get(`/${id}`, {
       ...HttpClient.clientConfig,
       ...requestConfig,
     });

--- a/components/app/CommentList.tsx
+++ b/components/app/CommentList.tsx
@@ -1,9 +1,9 @@
 import Image from "next/image";
-import { getTimeAgo } from "@/utils/date";
 import { useCommentList } from "@/models/portfolio";
 import { SubmitHandler, useForm } from "react-hook-form";
 import httpClient from "@/apis";
 import { useUser } from "@/hooks/useUser";
+import Comment from "../atoms/Comment";
 
 interface CommentForm {
   content: string;
@@ -41,32 +41,7 @@ export default function CommentList({ portfolioId }: { portfolioId?: number }) {
       </form>
       <div className="mt-2xlarge">
         {commentList.map((comment) => {
-          return (
-            <div
-              className="flex items-center mb-xlarge"
-              key={comment.commentId}
-            >
-              <Image
-                className="rounded-full mr-base"
-                src={comment.writer.profileImageUrl}
-                alt="프로필 사진"
-                width={40}
-                height={40}
-              />
-              <div>
-                <div className="flex items-center">
-                  <h2 className="font-bold text-small mr-xsmall">
-                    {comment.writer.name}
-                  </h2>
-                  ·{" "}
-                  <span className="text-primary-dark_gray text-xsmall">
-                    {getTimeAgo(comment.createdDate)}
-                  </span>
-                </div>
-                <p className="text-middle">{comment.content}</p>
-              </div>
-            </div>
-          );
+          return <Comment comment={comment} />;
         })}
       </div>
     </div>

--- a/components/app/CommentList.tsx
+++ b/components/app/CommentList.tsx
@@ -41,7 +41,7 @@ export default function CommentList({ portfolioId }: { portfolioId?: number }) {
         />
       </form>
       <div className="mt-2xlarge">
-        {commentList?.map((comment) => {
+        {commentList.map((comment) => {
           return <Comment comment={comment} refetch={refetch} />;
         })}
       </div>

--- a/components/app/CommentList.tsx
+++ b/components/app/CommentList.tsx
@@ -11,7 +11,7 @@ interface CommentForm {
 
 export default function CommentList({ portfolioId }: { portfolioId?: number }) {
   const { user } = useUser();
-  const { list: commentList } = useCommentList(portfolioId);
+  const { list: commentList, refetch } = useCommentList(portfolioId);
   const { register, handleSubmit } = useForm<CommentForm>();
 
   const onValid: SubmitHandler<CommentForm> = async (submitData) => {
@@ -40,8 +40,8 @@ export default function CommentList({ portfolioId }: { portfolioId?: number }) {
         />
       </form>
       <div className="mt-2xlarge">
-        {commentList.map((comment) => {
-          return <Comment comment={comment} />;
+        {commentList?.map((comment) => {
+          return <Comment comment={comment} refetch={refetch} />;
         })}
       </div>
     </div>

--- a/components/app/CommentList.tsx
+++ b/components/app/CommentList.tsx
@@ -19,6 +19,7 @@ export default function CommentList({ portfolioId }: { portfolioId?: number }) {
       portfolioId,
       ...submitData,
     });
+    refetch();
   };
 
   return (

--- a/components/atoms/Comment.tsx
+++ b/components/atoms/Comment.tsx
@@ -1,0 +1,86 @@
+import httpClient from "@/apis";
+import { Comment as CommentProps } from "@/types/portfolio.interface";
+import { getTimeAgo } from "@/utils/date";
+import Image from "next/image";
+import { useState } from "react";
+import Button from "./Button";
+
+export default function Comment({ comment }: { comment: CommentProps }) {
+  const [isEdit, setIsEdit] = useState(false);
+  const [editContent, setEditContent] = useState(comment.content);
+
+  const handleDelete = async (commentId: number) => {
+    try {
+      await httpClient.comment.delete({ data: { commentId } });
+      alert("삭제에 성공하였습니다");
+    } catch (error) {
+      alert("삭제에 실패하였습니다.");
+      throw error;
+    }
+  };
+
+  const handleEdit = async () => {
+    setIsEdit(true);
+  };
+
+  const handleEditCompleted = async (commentId: number) => {
+    await httpClient.comment.put({
+      commentId,
+      content: editContent,
+    });
+  };
+
+  return (
+    <div className="flex items-center mb-xlarge" key={comment.commentId}>
+      <Image
+        className="rounded-full mr-base"
+        src={comment.writer.profileImageUrl}
+        alt="프로필 사진"
+        width={40}
+        height={40}
+      />
+      <div className="w-full flex justify-between">
+        <div className="w-full">
+          <div className="flex items-center">
+            <h2 className="font-bold text-small mr-xsmall">
+              {comment.writer.name}
+            </h2>
+            ·{" "}
+            <span className="text-primary-dark_gray text-xsmall">
+              {getTimeAgo(comment.createdDate)}
+            </span>
+          </div>
+          {isEdit ? (
+            <>
+              <input
+                type="text"
+                className="w-full border-b border-b-primary-border_gray"
+                value={editContent}
+                onChange={(event) => {
+                  setEditContent(event.target.value);
+                }}
+              />
+              <Button
+                type="button"
+                onClick={() => handleEditCompleted(comment.commentId)}
+              >
+                완료
+              </Button>
+              <Button varient="secondary" type="button">
+                취소
+              </Button>
+            </>
+          ) : (
+            <p className="text-middle">{comment.content}</p>
+          )}
+        </div>
+        {comment.editable ? (
+          <div>
+            <span onClick={handleEdit}>수정</span>/
+            <span onClick={() => handleDelete(comment.commentId)}>삭제</span>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/components/atoms/Comment.tsx
+++ b/components/atoms/Comment.tsx
@@ -7,7 +7,6 @@ import {
   RefetchQueryFilters,
 } from "@tanstack/react-query";
 import Image from "next/image";
-import { useRouter } from "next/router";
 import { useState } from "react";
 import Button from "./Button";
 
@@ -35,6 +34,7 @@ export default function CommentView({ comment, refetch }: CommentViewProps) {
       commentId,
       content: editContent,
     });
+    setIsEdit(false);
     refetch();
   };
 

--- a/components/atoms/Comment.tsx
+++ b/components/atoms/Comment.tsx
@@ -14,7 +14,6 @@ export default function CommentView({ comment }: { comment: Comment }) {
   const handleDelete = async (commentId: number) => {
     try {
       await httpClient.comment.delete({ data: { commentId } });
-      alert("삭제에 성공하였습니다");
     } catch (error) {
       alert("삭제에 실패하였습니다.");
       throw error;
@@ -80,12 +79,12 @@ export default function CommentView({ comment }: { comment: Comment }) {
             <p className="text-middle">{comment.content}</p>
           )}
         </div>
-        {comment.editable ? (
+        {comment.editable && (
           <div>
             <span onClick={handleEdit}>수정</span>
             <span onClick={() => handleDelete(comment.commentId)}>삭제</span>
           </div>
-        ) : null}
+        )}
       </div>
     </div>
   );

--- a/components/atoms/Comment.tsx
+++ b/components/atoms/Comment.tsx
@@ -1,23 +1,29 @@
 import httpClient from "@/apis";
 import { Comment } from "@/types/portfolio.interface";
 import { getTimeAgo } from "@/utils/date";
+import {
+  QueryObserverResult,
+  RefetchOptions,
+  RefetchQueryFilters,
+} from "@tanstack/react-query";
 import Image from "next/image";
 import { useRouter } from "next/router";
 import { useState } from "react";
 import Button from "./Button";
 
-export default function CommentView({ comment }: { comment: Comment }) {
+interface CommentViewProps {
+  comment: Comment;
+  refetch: <TPageData>(
+    options?: RefetchOptions & RefetchQueryFilters<TPageData>,
+  ) => Promise<QueryObserverResult>;
+}
+
+export default function CommentView({ comment, refetch }: CommentViewProps) {
   const [isEdit, setIsEdit] = useState<boolean>(false);
   const [editContent, setEditContent] = useState<string>(comment.content);
-  const router = useRouter();
 
   const handleDelete = async (commentId: number) => {
-    try {
-      await httpClient.comment.delete({ data: { commentId } });
-    } catch (error) {
-      alert("삭제에 실패하였습니다.");
-      throw error;
-    }
+    await httpClient.comment.delete({ data: { commentId } });
   };
 
   const handleEdit = async () => {
@@ -25,17 +31,11 @@ export default function CommentView({ comment }: { comment: Comment }) {
   };
 
   const handleEditCompleted = async (commentId: number) => {
-    try {
-      await httpClient.comment.put({
-        commentId,
-        content: editContent,
-      });
-      alert("수정 성공");
-      router.reload();
-    } catch (error) {
-      alert("수정 실패.");
-      throw error;
-    }
+    await httpClient.comment.put({
+      commentId,
+      content: editContent,
+    });
+    refetch();
   };
 
   return (

--- a/components/atoms/Comment.tsx
+++ b/components/atoms/Comment.tsx
@@ -1,12 +1,12 @@
 import httpClient from "@/apis";
-import { Comment as CommentProps } from "@/types/portfolio.interface";
+import { Comment } from "@/types/portfolio.interface";
 import { getTimeAgo } from "@/utils/date";
 import Image from "next/image";
 import { useRouter } from "next/router";
 import { useState } from "react";
 import Button from "./Button";
 
-export default function Comment({ comment }: { comment: CommentProps }) {
+export default function CommentView({ comment }: { comment: Comment }) {
   const [isEdit, setIsEdit] = useState<boolean>(false);
   const [editContent, setEditContent] = useState<string>(comment.content);
   const router = useRouter();

--- a/components/atoms/Comment.tsx
+++ b/components/atoms/Comment.tsx
@@ -2,12 +2,14 @@ import httpClient from "@/apis";
 import { Comment as CommentProps } from "@/types/portfolio.interface";
 import { getTimeAgo } from "@/utils/date";
 import Image from "next/image";
+import { useRouter } from "next/router";
 import { useState } from "react";
 import Button from "./Button";
 
 export default function Comment({ comment }: { comment: CommentProps }) {
   const [isEdit, setIsEdit] = useState(false);
   const [editContent, setEditContent] = useState(comment.content);
+  const router = useRouter();
 
   const handleDelete = async (commentId: number) => {
     try {
@@ -20,14 +22,21 @@ export default function Comment({ comment }: { comment: CommentProps }) {
   };
 
   const handleEdit = async () => {
-    setIsEdit(true);
+    setIsEdit((prev) => !prev);
   };
 
   const handleEditCompleted = async (commentId: number) => {
-    await httpClient.comment.put({
-      commentId,
-      content: editContent,
-    });
+    try {
+      await httpClient.comment.put({
+        commentId,
+        content: editContent,
+      });
+      alert("수정 성공");
+      router.reload();
+    } catch (error) {
+      alert("수정 실패.");
+      throw error;
+    }
   };
 
   return (
@@ -45,8 +54,8 @@ export default function Comment({ comment }: { comment: CommentProps }) {
             <h2 className="font-bold text-small mr-xsmall">
               {comment.writer.name}
             </h2>
-            ·{" "}
-            <span className="text-primary-dark_gray text-xsmall">
+            <span>·</span>
+            <span className="ml-1 text-primary-dark_gray text-xsmall">
               {getTimeAgo(comment.createdDate)}
             </span>
           </div>
@@ -60,13 +69,10 @@ export default function Comment({ comment }: { comment: CommentProps }) {
                   setEditContent(event.target.value);
                 }}
               />
-              <Button
-                type="button"
-                onClick={() => handleEditCompleted(comment.commentId)}
-              >
+              <Button onClick={() => handleEditCompleted(comment.commentId)}>
                 완료
               </Button>
-              <Button varient="secondary" type="button">
+              <Button onClick={handleEdit} varient="secondary">
                 취소
               </Button>
             </>

--- a/components/atoms/Comment.tsx
+++ b/components/atoms/Comment.tsx
@@ -23,6 +23,7 @@ export default function CommentView({ comment, refetch }: CommentViewProps) {
 
   const handleDelete = async (commentId: number) => {
     await httpClient.comment.delete({ data: { commentId } });
+    refetch();
   };
 
   const handleEdit = async () => {

--- a/components/atoms/Comment.tsx
+++ b/components/atoms/Comment.tsx
@@ -7,8 +7,8 @@ import { useState } from "react";
 import Button from "./Button";
 
 export default function Comment({ comment }: { comment: CommentProps }) {
-  const [isEdit, setIsEdit] = useState(false);
-  const [editContent, setEditContent] = useState(comment.content);
+  const [isEdit, setIsEdit] = useState<boolean>(false);
+  const [editContent, setEditContent] = useState<string>(comment.content);
   const router = useRouter();
 
   const handleDelete = async (commentId: number) => {
@@ -82,7 +82,7 @@ export default function Comment({ comment }: { comment: CommentProps }) {
         </div>
         {comment.editable ? (
           <div>
-            <span onClick={handleEdit}>수정</span>/
+            <span onClick={handleEdit}>수정</span>
             <span onClick={() => handleDelete(comment.commentId)}>삭제</span>
           </div>
         ) : null}

--- a/components/index.ts
+++ b/components/index.ts
@@ -9,7 +9,7 @@ export { default as Portfolio } from "./common/Portfolio";
 export { default as AppDetail } from "./app/Detail";
 export { default as PortfolioPlayer } from "./app/PortfolioPlayer";
 export { default as AppSideMenu } from "./app/SideMenu";
-export { default as AppComment } from "./app/Comment";
+export { default as AppComment } from "./app/CommentList";
 export { default as MyPageProfile } from "./app/MyPageProfile";
 export { default as MyPagePortfolioList } from "./app/MyPagePortfolioList";
 export { default as MainPortfolioList } from "./main/MainPortfolioList";

--- a/fixtures/index.ts
+++ b/fixtures/index.ts
@@ -6,12 +6,17 @@ const avatarUrl =
 const portfolioUrl = "/assets/images/testPortfolioThumbnail.png";
 
 const comment: Comment = {
+  writer: {
+    memberId: 0,
+    name: "string",
+    profileImageUrl:
+      "https://pbs.twimg.com/profile_images/1374979417915547648/vKspl9Et_400x400.jpg",
+    email: " string@gmail.com",
+  },
   commentId: 0,
-  userProfile:
-    "https://pbs.twimg.com/profile_images/1374979417915547648/vKspl9Et_400x400.jpg",
-  userName: "사람 이름1",
   content: "댓글 내용입니다.",
   createdDate: new Date("2022-12-01"),
+  editable: false,
 };
 
 const portfolio: Portfolio = {

--- a/models/portfolio/index.ts
+++ b/models/portfolio/index.ts
@@ -24,7 +24,7 @@ const useCommentList = (portfolioId?: number) => {
     () => httpClient.comment.getById(portfolioId as number).then((r) => r.data),
     { enabled: portfolioId != null },
   );
-  return { ...data, refetch } || { list: [], refetch };
+  return { list: data?.list && [], refetch };
 };
 
 export { usePortfolioList, usePortfolio, useCommentList };

--- a/models/portfolio/index.ts
+++ b/models/portfolio/index.ts
@@ -24,7 +24,7 @@ const useCommentList = (portfolioId?: number) => {
     () => httpClient.comment.getById(portfolioId as number).then((r) => r.data),
     { enabled: portfolioId != null },
   );
-  return { list: data?.list && [], refetch };
+  return { list: data?.list ?? [], refetch };
 };
 
 export { usePortfolioList, usePortfolio, useCommentList };

--- a/models/portfolio/index.ts
+++ b/models/portfolio/index.ts
@@ -1,6 +1,6 @@
 import httpClient from "@/apis";
 import fixture from "@/fixtures";
-import { PortfolioList } from "@/types/portfolio.interface";
+import { Comment, PortfolioList } from "@/types/portfolio.interface";
 import { useQuery } from "@tanstack/react-query";
 
 const usePortfolioList = () => {
@@ -13,19 +13,6 @@ const usePortfolioList = () => {
 const usePortfolio = () => {
   return { data: fixture.portfolio };
 };
-
-interface Comment {
-  writer: {
-    memberId: number;
-    name: string;
-    profileImageUrl: string;
-    email: string;
-  };
-  commentId: number;
-  content: string;
-  createdDate: Date;
-  editable: boolean;
-}
 
 interface CommentList {
   list: Comment[];

--- a/models/portfolio/index.ts
+++ b/models/portfolio/index.ts
@@ -3,6 +3,10 @@ import fixture from "@/fixtures";
 import { Comment, PortfolioList } from "@/types/portfolio.interface";
 import { useQuery } from "@tanstack/react-query";
 
+interface CommentList {
+  list: Comment[];
+}
+
 const usePortfolioList = () => {
   const { data } = useQuery<PortfolioList>(["portfolioList"], () =>
     httpClient.portfolio.search({}).then((d) => d.data),
@@ -14,20 +18,13 @@ const usePortfolio = () => {
   return { data: fixture.portfolio };
 };
 
-interface CommentList {
-  list: Comment[];
-}
-
 const useCommentList = (portfolioId?: number) => {
-  const { data } = useQuery<CommentList>(
+  const { data, refetch } = useQuery<CommentList>(
     ["comment", portfolioId],
-    () =>
-      httpClient.comment
-        .getById({ params: { id: portfolioId } })
-        .then((r) => r.data),
-    { enabled: !!portfolioId },
+    () => httpClient.comment.getById(portfolioId as number).then((r) => r.data),
+    { enabled: portfolioId != null },
   );
-  return data || { list: [] };
+  return { ...data, refetch } || { list: [], refetch };
 };
 
 export { usePortfolioList, usePortfolio, useCommentList };

--- a/pages/portfolio/[id].tsx
+++ b/pages/portfolio/[id].tsx
@@ -57,8 +57,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
       notFound: true,
     };
 
-  const portfolio = (await httpClient.portfolio.getById({ params: { id } }))
-    .data;
+  const portfolio = (await httpClient.portfolio.getById(Number(id))).data;
 
   return {
     props: {

--- a/types/portfolio.interface.ts
+++ b/types/portfolio.interface.ts
@@ -50,13 +50,17 @@ export interface PortfolioList {
 }
 
 export interface Comment {
+  writer: {
+    memberId: number;
+    name: string;
+    profileImageUrl: string;
+    email: string;
+  };
   commentId: number;
-  userProfile: string;
-  userName: string;
   content: string;
   createdDate: Date;
+  editable: boolean;
 }
-
 export interface Description {
   description: string;
 }


### PR DESCRIPTION
## 지라 이슈
https://qkrjh0904.atlassian.net/browse/BSSMH-117

## 스크린샷

https://user-images.githubusercontent.com/80014454/218296470-4744ffed-3fe2-44d4-afa7-d20858beed66.mov


## 변경한 것
댓글 수정, 삭제 기능을 추가하였습니다.
자세한 디자인이 나오지 않아 일단 기능만 구현한 상태이며 
수정, 삭제를 할 때 그냥 페이지를 reload 하도록 해놓았는데 혹시 다른 더 좋은 방법이 있다면 조언 부탁드립니다!
(제가 생각한 방법은 수정, 삭제를 할 때 보여지는 값의 state만 변경해주고 서버로 요청을 보내서 사용자가 수정된 것 처럼 볼 수 있게 하는 방법인데 이 방법이 진짜 좋은 해결책이 맞는지 모르겠어서 아직 적용하지 않았습니다!)
