### PR TITLE
파일 업로더 id가 겹치는 문제 수정

### DIFF
--- a/components/app/MyPagePortfolioList.tsx
+++ b/components/app/MyPagePortfolioList.tsx
@@ -10,7 +10,7 @@ export default function MyPagePortfolioList({
   const router = useRouter();
 
   return (
-    <div className="grid grid-cols-[320px_320px] gap-12 ml-[4.5rem]">
+    <div className="grid grid-cols-[20rem_20rem] gap-12 ml-[4.5rem]">
       {myPortfolioList.map((myPortfolio) => {
         return (
           <PortfolioView

--- a/components/app/UploadModal/FileUploadView.tsx
+++ b/components/app/UploadModal/FileUploadView.tsx
@@ -38,10 +38,12 @@ export default function FileUploadView({
         <h2 className="mb-2">동영상</h2>
         <div className="w-full border h-60 mb-2.5 flex flex-col justify-center items-center border-primary-border_gray gap-2.5 rounded-lg">
           <FileUploader
+            id="thumbnail-uploader"
             label="썸네일 업로드"
             onChange={(e) => handleFileUpload(e, setThumbnailFileUid)}
           />
           <FileUploader
+            id="video-uploader"
             label="동영상 업로드"
             onChange={(e) => handleFileUpload(e, setVideoFileUid)}
           />

--- a/components/app/UploadModal/index.tsx
+++ b/components/app/UploadModal/index.tsx
@@ -18,19 +18,19 @@ const MAX_NAVIGATOR_LENGTH = 3;
 export default function UploadModal({ closeModal }: UploadModalProps) {
   const [pageIndex, setPageIndex] = useState(0);
   const [selectedSkills, setSelectedSkills] = useState<Skill[]>([]);
+  const [videoFileUid, setVideoFileUid] = useState<string>("");
+  const [thumbnailFileUid, setThumbnailFileUid] = useState<string>("");
   const {
     register,
     handleSubmit,
     // watch,
     // formState: { errors },
   } = useForm<PortfolioForm>();
-  const [videoFileUid, setVideoFileUid] = useState<string>("");
-  const [thumbnailFileUid, setThumbnailFileUid] = useState<string>("");
 
   const onValid: SubmitHandler<PortfolioForm> = async (data) => {
     await httpClient.portfolio.post({
       ...data,
-      portfolioType: "URL",
+      portfolioType: "VIDEO",
       skillList: selectedSkills,
       contributorIdList: [0],
       videoFileUid,

--- a/components/atoms/Comment.tsx
+++ b/components/atoms/Comment.tsx
@@ -1,20 +1,14 @@
 import httpClient from "@/apis";
+import { RefetchType } from "@/types/index.interface";
 import { Comment } from "@/types/portfolio.interface";
 import { getTimeAgo } from "@/utils/date";
-import {
-  QueryObserverResult,
-  RefetchOptions,
-  RefetchQueryFilters,
-} from "@tanstack/react-query";
 import Image from "next/image";
 import { useState } from "react";
 import Button from "./Button";
 
 interface CommentViewProps {
   comment: Comment;
-  refetch: <TPageData>(
-    options?: RefetchOptions & RefetchQueryFilters<TPageData>,
-  ) => Promise<QueryObserverResult>;
+  refetch: RefetchType;
 }
 
 export default function CommentView({ comment, refetch }: CommentViewProps) {

--- a/layouts/App.tsx
+++ b/layouts/App.tsx
@@ -26,10 +26,9 @@ function Frame({ app, sidebar, detail, comment }: FrameProps) {
       <div className="w-full">
         {app}
         {detail}
-        <div className="hidden xl:block">{comment}</div>
+        {comment}
       </div>
       <div className="mt-base xl:mt-0 xl:row-span-2">{sidebar}</div>
-      <div className="block xl:hidden">{comment}</div>
     </section>
   );
 }

--- a/layouts/App.tsx
+++ b/layouts/App.tsx
@@ -9,24 +9,27 @@ interface FrameProps {
 
 const getLayoutCss = () => {
   return `
-  grid 
+  flex
+  flex-col
+  justify-between
   pt-[3.25rem] 
   px-4
   md:px-6
   xl:px-[6.25rem]
-  xl:grid-cols-[minmax(0,_1fr)_28.25rem] 
+  xl:flex-row
   `;
 };
 
 function Frame({ app, sidebar, detail, comment }: FrameProps) {
   return (
     <section className={getLayoutCss()}>
-      <div>
-        <div>{app}</div>
-        <div>{detail}</div>
+      <div className="w-full">
+        {app}
+        {detail}
+        <div className="hidden xl:block">{comment}</div>
       </div>
       <div className="mt-base xl:mt-0 xl:row-span-2">{sidebar}</div>
-      <div>{comment}</div>
+      <div className="block xl:hidden">{comment}</div>
     </section>
   );
 }

--- a/types/index.interface.ts
+++ b/types/index.interface.ts
@@ -1,0 +1,9 @@
+import {
+  QueryObserverResult,
+  RefetchOptions,
+  RefetchQueryFilters,
+} from "@tanstack/react-query";
+
+export type RefetchType = <TPageData>(
+  options?: RefetchOptions & RefetchQueryFilters<TPageData>,
+) => Promise<QueryObserverResult>;


### PR DESCRIPTION
## 지라 이슈
https://qkrjh0904.atlassian.net/browse/BSSMH-65

## 스크린샷
<img width="1127" alt="스크린샷 2023-02-16 오전 11 49 39" src="https://user-images.githubusercontent.com/80014454/219257998-c1b0a6ef-0a99-4866-8e95-b170c9f4eaa6.png">


## 변경한 것
썸네일이 안보이는 원인이 썸네일Uid에 영상의Uid를 넣어서 생긴 문제였습니다.
파일업로더 2개의 id가 겹쳐서 썸네일과 영상이 같은 변수를 공유하고 있었습니다.
2개의 파일업로더의 id를 개별적으로 부여해서 이 문제를 해결하였습니다.

추가적으로 refetch의 타입이 너무 길어서 index.interface.ts에 따로 만들주었습니다!