### PR TITLE
검색 안되는 버그 수정

### DIFF
--- a/models/portfolio/index.ts
+++ b/models/portfolio/index.ts
@@ -17,7 +17,10 @@ const usePortfolioList = (pagination: PaginationRequest, filter?: Filter) => {
       ["portfolioList"],
       ({ pageParam = 1 }) =>
         httpClient.portfolio
-          .search({ pagination: { ...pagination, page: pageParam }, filter })
+          .search({
+            pagination: { ...pagination, page: pageParam },
+            filter: filter || {},
+          })
           .then((r) => r.data),
       {
         getNextPageParam: (lastPage) => lastPage.pagination.page + 1,


### PR DESCRIPTION
## 지라 이슈
없습니다!

## 스크린샷
없습니다!

## 변경한 것
검색 post filter를 optional 로 해놓고 기본값을 안줘서 500이 뜨는 버그를 수정했습니다