### PR TITLE
마크다운 추가

### DIFF
--- a/components/app/Detail.tsx
+++ b/components/app/Detail.tsx
@@ -147,7 +147,7 @@ export default function Detail({
           )}
         </div>
       </div>
-      <Description description={portfolio.description} />
+      <Description>{portfolio.description}</Description>
     </div>
   );
 }

--- a/components/app/MemberProfile/ProfilePageProfile.tsx
+++ b/components/app/MemberProfile/ProfilePageProfile.tsx
@@ -1,10 +1,12 @@
 import httpClient from "@/apis";
 import Button from "@/components/atoms/Button";
 import Avatar from "@/components/common/Avatar";
+import DescriptionView from "@/components/portfolio/Description";
 import useOverlay from "@/hooks/useOverlay";
 import KEY from "@/models/key";
 import { Member } from "@/types/member.interface";
 import { useQueryClient } from "@tanstack/react-query";
+import Markdown from "marked-react";
 import { useRouter } from "next/router";
 
 interface MemberPageProfileProps {
@@ -70,9 +72,9 @@ export default function MemberPageProfile({
             <span className="mr-3">팔로잉 수</span>
             <span>{followingCount}</span>
           </div>
-          <pre className="overflow-y-scroll max-w-[17.625rem] whitespace-pre-wrap text-xs mb-5">
-            {userInfo.description}
-          </pre>
+          <article className="overflow-y-scroll max-w-[17.625rem] whitespace-pre-wrap text-xs mb-5">
+            <DescriptionView>{userInfo.description || ""}</DescriptionView>
+          </article>
         </div>
         <div className="flex justify-center mt-auto">
           {/* {isMypage && (

--- a/components/portfolio/Description.tsx
+++ b/components/portfolio/Description.tsx
@@ -1,10 +1,10 @@
 import Markdown from "marked-react";
 import { Description } from "@/types/portfolio.interface";
 
-export default function DescriptionView({ description }: Description) {
+export default function DescriptionView({ children }: Description) {
   return (
-    <div className="px-large py-small bg-primary-light_gray rounded">
-      <Markdown>{description}</Markdown>
+    <div className="prose">
+      <Markdown>{children}</Markdown>
     </div>
   );
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dev:e2e": "NODE_ENV=development && playwright test"
   },
   "dependencies": {
+    "@tailwindcss/typography": "^0.5.9",
     "@tanstack/react-query": "^4.22.0",
     "@types/react-copy-to-clipboard": "^5.0.4",
     "@types/uuid": "^9.0.1",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -126,5 +126,6 @@ module.exports = {
     // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
     require("tailwind-scrollbar")({ nocompatible: true }),
     require("tailwind-scrollbar-hide"),
+    require("@tailwindcss/typography"),
   ],
 };

--- a/types/portfolio.interface.ts
+++ b/types/portfolio.interface.ts
@@ -112,5 +112,5 @@ export interface Comment {
   editable: boolean;
 }
 export interface Description {
-  description: string;
+  children: string;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -827,6 +827,16 @@
   dependencies:
     tslib "^2.4.0"
 
+"@tailwindcss/typography@^0.5.9":
+  version "0.5.9"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/typography/-/typography-0.5.9.tgz#027e4b0674929daaf7c921c900beee80dbad93e8"
+  integrity sha512-t8Sg3DyynFysV9f4JDOVISGsjazNb48AeIYQwcL+Bsq5uf4RYL75C1giZ43KISjeDGBaTN3Kxh7Xj/vRSMJUUg==
+  dependencies:
+    lodash.castarray "^4.4.0"
+    lodash.isplainobject "^4.0.6"
+    lodash.merge "^4.6.2"
+    postcss-selector-parser "6.0.10"
+
 "@tanstack/match-sorter-utils@^8.7.0":
   version "8.7.6"
   resolved "https://registry.yarnpkg.com/@tanstack/match-sorter-utils/-/match-sorter-utils-8.7.6.tgz#ccf54a37447770e0cf0fe49a579c595fd2655b16"
@@ -3530,6 +3540,16 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
+lodash.castarray@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.castarray/-/lodash.castarray-4.4.0.tgz#c02513515e309daddd4c24c60cfddcf5976d9115"
+  integrity sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==
+
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  integrity sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==
+
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
@@ -3990,6 +4010,14 @@ postcss-nested@6.0.0:
   integrity sha512-0DkamqrPcmkBDsLn+vQDIrtkSbNkv5AD/M322ySo9kqFkCIYklym2xEmWkwo+Y3/qZo34tzEPNUw4y7yMCdv5w==
   dependencies:
     postcss-selector-parser "^6.0.10"
+
+postcss-selector-parser@6.0.10:
+  version "6.0.10"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz#79b61e2c0d1bfc2602d549e11d0876256f8df88d"
+  integrity sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==
+  dependencies:
+    cssesc "^3.0.0"
+    util-deprecate "^1.0.2"
 
 postcss-selector-parser@^6.0.10, postcss-selector-parser@^6.0.11:
   version "6.0.11"


### PR DESCRIPTION
## 지라 이슈
https://qkrjh0904.atlassian.net/browse/BSSMH-168

## 스크린샷
![스크린샷 2023-03-01 오후 3 03 37](https://user-images.githubusercontent.com/80014454/222058270-87d6771e-0398-49b4-aebc-4304e7f6cc45.png)
![스크린샷 2023-03-01 오후 3 03 41](https://user-images.githubusercontent.com/80014454/222058283-d95b9abb-238b-4b41-8b8a-078002389fb2.png)
![스크린샷 2023-03-01 오후 3 03 48](https://user-images.githubusercontent.com/80014454/222058285-1097311d-59c4-42ee-8cce-4f0474e771ca.png)
![스크린샷 2023-03-01 오후 3 03 49](https://user-images.githubusercontent.com/80014454/222058287-5c62b7ac-15dc-4ae4-84ff-9fc03a9999a7.png)

## 변경한 것
마크다운을 추가하였습니다. 
테일윈드 공식 typography 라이브러리는 테일윈드 reset.css를 무시하고 h1태그를 h1처럼 보이도록 해주는 라이브러리여서
마크다운 라이브러리로 마크다운 문법을 HTML태그로 전처리를 하고 typograpy라이브러리로 h1을 h1처럼 보이도록 만들어주었습니다!