### PR TITLE
chip group width 수정

### DIFF
--- a/components/atoms/Chip.tsx
+++ b/components/atoms/Chip.tsx
@@ -24,7 +24,7 @@ function Group({ children, className, type = "main" }: ChipGroupProps) {
         "flex flex-wrap gap-1.5 py-1 xl:w-32",
         {
           "!w-full": type === "detail" || "upload",
-          "!w-[150px]": type === "portfolio",
+          "xl:!w-40": type === "portfolio",
         },
       )}`}
     >


### PR DESCRIPTION
## 지라 이슈
지라 이슈는 없습니다

## 스크린샷
큰 화면일 경우
![스크린샷 2023-03-03 오후 11 19 16](https://user-images.githubusercontent.com/80014454/222743920-b302058e-562c-4668-9868-72e7a9c8d404.png)
작은 화면일 경우
![스크린샷 2023-03-03 오후 11 19 11](https://user-images.githubusercontent.com/80014454/222743872-02efe0a8-978e-4116-8043-85433069174d.png)

## 변경한 것
현재 배포된 서버에 chip-group의 width가 잘못 설정되어 깨지는 문제가 있어, 이를 수정했습니다.