### PR TITLE
BSM 프로필 사진 없을 경우 수정

### DIFF
--- a/components/app/CommentList.tsx
+++ b/components/app/CommentList.tsx
@@ -5,6 +5,7 @@ import { useRef, useState } from "react";
 import { checkInputValueIsNull } from "@/utils/input";
 import httpClient from "@/apis";
 import useUser from "@/hooks/useUser";
+import config from "@/config";
 import Comment from "../atoms/Comment";
 import InputButton from "../atoms/InputButton";
 
@@ -41,7 +42,7 @@ export default function CommentList({ portfolioId }: { portfolioId?: number }) {
     <div className="bg-white mt-2 p-3 box-border rounded">
       <form className="flex mt-base relative" onSubmit={handleSubmit(onValid)}>
         <Image
-          src={userInfo.profileImageUrl}
+          src={userInfo.profileImageUrl || config.defaultProfile}
           alt="프로필"
           width={40}
           height={40}

--- a/components/common/Avatar.tsx
+++ b/components/common/Avatar.tsx
@@ -23,15 +23,12 @@ export default function Avatar({
       className={classNames(className, "rounded-full", {
         "h-[40px]": height === 40,
       })}
-      src={imageUrl || ""}
+      src={imageUrl || config.defaultProfile}
       alt="사용자 아바타"
       width={width}
       height={height}
       sizes="40px"
       priority
-      onError={(event) => {
-        event.currentTarget.src = config.defaultProfile;
-      }}
     />
   );
 }


### PR DESCRIPTION
## 지라 이슈
https://qkrjh0904.atlassian.net/browse/BSSMH-172

## 스크린샷
현재 배포환경에서 BSM프로필이 없는 경우 기본프로필로 보여지도록 에러처리를 안해서 에러가 발생했습니다!
<img width="1724" alt="스크린샷 2023-03-08 오후 3 14 15" src="https://user-images.githubusercontent.com/80014454/223633859-fec96cd9-2a3d-49a7-804e-ccd10c38c0b8.png">

## 변경한 것
댓글, 헤더 레이아웃에 기본 프로필 이미지를 추가했습니다.