### PR TITLE
포트폴리오 수정 로직 관련 이슈 해결

### DIFF
--- a/components/portfolio/edit/index.tsx
+++ b/components/portfolio/edit/index.tsx
@@ -56,7 +56,7 @@ export default function PortfolioEdit({ portfolioId }: PortfolioEditProps) {
       if (editVideoFile)
         return getFileUidByFileUpload(editVideoFile, openToast);
       if (videoFileUid && !editVideoFile) return videoFileUid;
-      return undefined;
+      return "299ae74e-dbda-4def-a3b0-0939aadd997c.mp4";
     };
 
     const getThumbnailFileUid = () => {
@@ -72,8 +72,20 @@ export default function PortfolioEdit({ portfolioId }: PortfolioEditProps) {
         portfolioType: getPortfolioType(),
         skillList: selectedSkills,
         contributorIdList: selectedMembers.map((member) => member.memberId),
-        videoFileUid: await getVideoFileUid(),
-        thumbnailFileUid: await getThumbnailFileUid(),
+        videoFileUid: (await getVideoFileUid()) || undefined,
+        thumbnailFileUid: (await getThumbnailFileUid()) || "ㅇㅇㅇ",
+        video: undefined,
+        thumbnail: undefined,
+        writer: undefined,
+        scope: undefined,
+        contributorList: undefined,
+        bookmarks: undefined,
+        bookmarkYn: undefined,
+        followYn: undefined,
+        views: undefined,
+        comments: undefined,
+        recommendStatus: undefined,
+        createdDate: undefined,
       })
       .then(() => {
         openToast("수정이 완료되었습니다.");

--- a/components/portfolio/edit/index.tsx
+++ b/components/portfolio/edit/index.tsx
@@ -43,7 +43,7 @@ export default function PortfolioEdit({ portfolioId }: PortfolioEditProps) {
 
   const onValid: SubmitHandler<PortfolioForm> = async (data) => {
     const getPortfolioType = (): PortfolioType => {
-      if (data.portfolioUrl.length > 0 && videoFileUid) {
+      if (data.portfolioUrl.length > 0 && (videoFileUid || editVideoFile)) {
         return "ALL";
       }
       if (videoFileUid) {

--- a/utils/file.ts
+++ b/utils/file.ts
@@ -19,9 +19,9 @@ export const getFileUidByFileUpload = async (
 ) => {
   return httpClient.file
     .upload(getFormData(file))
-    .then(({ data }) => {
+    .then((r) => {
       openToast("파일 업로드에 성공하였습니다.");
-      return data.fileUid;
+      return r.data.fileUid;
     })
     .catch(() =>
       openToast("파일 업로드에 실패하였습니다.", { type: "danger" }),


### PR DESCRIPTION
## 지라 이슈
지라 이슈는 없습니다.

## 스크린샷
스크린샷은 없습니다.

## 변경한 것
* 수정 시 포트폴리오 타입을 정의하는 로직 파일을 업로드하는 로직보다 더 빨리 실행되어 동영상이 없는 포트폴리오에 동영상을 업로드 할 경우, URL타입 포트폴리오로 판별되는 로직 오류를 수정하였습니다! (동영상 업로드보다 더 빨리 포트폴리오 타입을 정의하는 문제입니다)
* 포트폴리오 수정 시 videoFileUid가 없을 경우 put 요청을 할 때 400이 뜨는 문제가 있어서 일단 임시로 동영상 UID를 기본값으로 추가했습니다.